### PR TITLE
Fixes for "function declaration isn't a prototype"

### DIFF
--- a/lib/python.go
+++ b/lib/python.go
@@ -9,7 +9,7 @@ package py
 // static inline int enterRecursive(char *w) {
 //     return Py_EnterRecursiveCall(w);
 // }
-// static inline void leaveRecursive() {
+// static inline void leaveRecursive(void) {
 //     Py_LeaveRecursiveCall();
 // }
 import "C"

--- a/lib/tuple.go
+++ b/lib/tuple.go
@@ -7,7 +7,7 @@ package py
 // #include "utils.h"
 // static inline int tupleCheck(PyObject *o) { return PyTuple_Check(o); }
 // static inline int tupleCheckE(PyObject *o) { return PyTuple_CheckExact(o); }
-// static inline size_t tupleItemSize() { return sizeof(PyObject *); }
+// static inline size_t tupleItemSize(void) { return sizeof(PyObject *); }
 import "C"
 
 import (

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -101,7 +101,7 @@ typedef struct {
     PySequenceMethods sq_meth;
 } ClassContext;
 
-extern PyMethodDef *newMethodDef();
+extern PyMethodDef *newMethodDef(void);
 extern void set_call_noargs(PyCFunction *f);
 extern void set_call_args(PyCFunction *f);
 extern void set_call_keywords(PyCFunction *f);


### PR DESCRIPTION
I was seeing errors like:
"In file included from abstract.go:7:
utils.h:104: warning: function declaration isn't a prototype"
which this fixes.
(See http://stackoverflow.com/questions/42125/function-declaration-isnt-a-prototype/47693#47693.)
