### PR TITLE
Go 1.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: false
 language: go
 
 go:
-  - 1.5
+  - 1.7.3
   - tip
 
 os:
@@ -18,6 +18,11 @@ addons:
       - libonig-dev
       - python3.5
       - python3.5-dev
+
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update         ; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install python3; fi
 
 install:
   - go get golang.org/x/tools/cmd/cover

--- a/abstract.go
+++ b/abstract.go
@@ -16,9 +16,9 @@ import "unsafe"
 // concrete types to provide the Object interface functions.
 type AbstractObject struct{}
 
-func newAbstractObject(obj *C.PyObject) *AbstractObject {
-	return (*AbstractObject)(unsafe.Pointer(obj))
-}
+// func newAbstractObject(obj *C.PyObject) *AbstractObject {
+// 	return (*AbstractObject)(unsafe.Pointer(obj))
+// }
 
 // Init initialises obj.  It is equivalent to "obj.__init__(*args, **kw)" in
 // Python.

--- a/base.go
+++ b/base.go
@@ -18,14 +18,21 @@ import "unsafe"
 // accept any type of object to be defined as methods on *BaseObject.
 type BaseObject struct {
 	AbstractObject
-	o C.PyObject
+	o *C.PyObject
 }
 
+var baseObjMap = make(map[*C.PyObject]*BaseObject)
+
 // BaseType is the Type object that represents the BaseObject type.
-var BaseType = (*Type)(unsafe.Pointer(C.getBasePyType(C.GoPyBaseObject_Type)))
+var BaseType = newType((*C.PyObject)(unsafe.Pointer(C.getBasePyType(C.GoPyBaseObject_Type))))
 
 func newBaseObject(obj *C.PyObject) *BaseObject {
-	return (*BaseObject)(unsafe.Pointer(obj))
+	if bo, ok := baseObjMap[obj]; ok {
+		return bo
+	}
+	bo := &BaseObject{o: obj}
+	baseObjMap[obj] = bo
+	return bo
 }
 
 // HasAttr returns true if "obj" has the attribute "name".  This is equivalent

--- a/bool.go
+++ b/bool.go
@@ -20,19 +20,19 @@ import (
 // same instance, and every False value refers to the same value.
 type Bool struct {
 	AbstractObject
-	o C.PyObject
+	o *C.PyObject
 }
 
 // BoolType is the Type object that represents the Bool type.
-var BoolType = (*Type)(unsafe.Pointer(C.getBasePyType(C.GoPyBool_Type)))
+var BoolType = newType((*C.PyObject)(unsafe.Pointer(C.getBasePyType(C.GoPyBool_Type))))
 
 // True is the true value of the Bool type.  It is a singleton value, all true
 // values refer to the same instance.
-var True = (*Bool)(C.pyTrue())
+var True = &Bool{o: (*C.PyObject)(C.pyTrue())}
 
 // False is the false value of the Bool type.  It is a singleton value, all
 // false values refer to the same instance.
-var False = (*Bool)(C.pyFalse())
+var False = &Bool{o: (*C.PyObject)(C.pyFalse())}
 
 func boolCheck(obj Object) bool {
 	return C.boolCheck(c(obj)) != 0

--- a/cfunction.go
+++ b/cfunction.go
@@ -15,8 +15,10 @@ import (
 
 type CFunction struct {
 	AbstractObject
-	o C.PyCFunctionObject
+	o *C.PyCFunctionObject
 }
+
+var cfunctionObjMap = make(map[*C.PyObject]*CFunction)
 
 func cfunctionCheck(obj Object) bool {
 	if obj == nil {
@@ -26,7 +28,12 @@ func cfunctionCheck(obj Object) bool {
 }
 
 func newCFunction(obj *C.PyObject) *CFunction {
-	return (*CFunction)(unsafe.Pointer(obj))
+	if cf, ok := cfunctionObjMap[obj]; ok {
+		return cf
+	}
+	cf := &CFunction{o: (*C.PyCFunctionObject)(unsafe.Pointer(obj))}
+	cfunctionObjMap[obj] = cf
+	return cf
 }
 
 func NewCFunction(name string, fn interface{}, doc string) (*CFunction, error) {

--- a/code.go
+++ b/code.go
@@ -12,14 +12,21 @@ import "unsafe"
 
 type Code struct {
 	AbstractObject
-	o C.PyCodeObject
+	o *C.PyCodeObject
 }
 
+var codeObjMap = make(map[*C.PyObject]*Code)
+
 // CodeType is the Type object that represents the Code type.
-var CodeType = (*Type)(unsafe.Pointer(C.getBasePyType(C.GoPyCode_Type)))
+var CodeType = newType((*C.PyObject)(unsafe.Pointer(C.getBasePyType(C.GoPyCode_Type))))
 
 func newCode(obj *C.PyObject) *Code {
-	return (*Code)(unsafe.Pointer(obj))
+	if c, ok := codeObjMap[obj]; ok {
+		return c
+	}
+	c := &Code{o: (*C.PyCodeObject)(unsafe.Pointer(obj))}
+	codeObjMap[obj] = c
+	return c
 }
 
 func CompileFile(name string) (*Code, error) {

--- a/complex.go
+++ b/complex.go
@@ -16,18 +16,25 @@ import (
 type Complex struct {
 	AbstractObject
 	NumberProtocol
-	o C.PyComplexObject
+	o *C.PyComplexObject
 }
 
+var complexObjMap = make(map[*C.PyObject]*Complex)
+
 // ComplexType is the Type object that represents the Complex type.
-var ComplexType = (*Type)(unsafe.Pointer(C.getBasePyType(C.GoPyComplex_Type)))
+var ComplexType = newType((*C.PyObject)(unsafe.Pointer(C.getBasePyType(C.GoPyComplex_Type))))
 
 func complexCheck(obj Object) bool {
 	return C.complexCheck(c(obj)) != 0
 }
 
 func newComplex(obj *C.PyObject) *Complex {
-	return (*Complex)(unsafe.Pointer(obj))
+	if c, ok := complexObjMap[obj]; ok {
+		return c
+	}
+	c := &Complex{o: (*C.PyComplexObject)(unsafe.Pointer(obj))}
+	complexObjMap[obj] = c
+	return c
 }
 
 func NewComplex(v complex128) (*Complex, error) {

--- a/dict.go
+++ b/dict.go
@@ -19,11 +19,13 @@ import (
 // the PyDict_XXX functions from the Python C API.
 type Dict struct {
 	AbstractObject
-	o C.PyDictObject
+	o *C.PyDictObject
 }
 
+var dictObjMap = make(map[*C.PyObject]*Dict)
+
 // DictType is the Type object that represents the Dict type.
-var DictType = (*Type)(unsafe.Pointer(C.getBasePyType(C.GoPyDict_Type)))
+var DictType = newType((*C.PyObject)(unsafe.Pointer(C.getBasePyType(C.GoPyDict_Type))))
 
 func dictCheck(obj Object) bool {
 	if obj == nil {
@@ -33,7 +35,12 @@ func dictCheck(obj Object) bool {
 }
 
 func newDict(obj *C.PyObject) *Dict {
-	return (*Dict)(unsafe.Pointer(obj))
+	if di, ok := dictObjMap[obj]; ok {
+		return di
+	}
+	di := &Dict{o: (*C.PyDictObject)(unsafe.Pointer(obj))}
+	dictObjMap[obj] = di
+	return di
 }
 
 // NewDict creates a new empty dictionary.
@@ -96,6 +103,7 @@ func (d *Dict) SetItem(key, val Object) error {
 // with a *String with the value of "key" will be used as the key).  If "key" is
 // not hashable, then a TypeError will be returned.
 func (d *Dict) SetItemString(key string, val Object) error {
+	fmt.Printf("SetItemString: [%s] = %T\n", key, val)
 	s := C.CString(key)
 	defer C.free(unsafe.Pointer(s))
 	ret := C.PyDict_SetItemString(c(d), s, c(val))

--- a/dict.go
+++ b/dict.go
@@ -103,7 +103,6 @@ func (d *Dict) SetItem(key, val Object) error {
 // with a *String with the value of "key" will be used as the key).  If "key" is
 // not hashable, then a TypeError will be returned.
 func (d *Dict) SetItemString(key string, val Object) error {
-	fmt.Printf("SetItemString: [%s] = %T\n", key, val)
 	s := C.CString(key)
 	defer C.free(unsafe.Pointer(s))
 	ret := C.PyDict_SetItemString(c(d), s, c(val))

--- a/exceptions.go
+++ b/exceptions.go
@@ -13,11 +13,18 @@ import (
 
 type ExceptionClass struct {
 	AbstractObject
-	o C.PyBaseExceptionObject
+	o *C.PyBaseExceptionObject
 }
 
+var exceptionObjMap = make(map[*C.PyObject]*ExceptionClass)
+
 func newException(obj *C.PyObject) *ExceptionClass {
-	return (*ExceptionClass)(unsafe.Pointer(obj))
+	if e, ok := exceptionObjMap[obj]; ok {
+		return e
+	}
+	e := &ExceptionClass{o: (*C.PyBaseExceptionObject)(unsafe.Pointer(obj))}
+	exceptionObjMap[obj] = e
+	return e
 }
 
 // ErrV returns a new Error of the specified kind, and with the given value.

--- a/float.go
+++ b/float.go
@@ -16,18 +16,25 @@ import (
 type Float struct {
 	AbstractObject
 	NumberProtocol
-	o C.PyFloatObject
+	o *C.PyFloatObject
 }
 
+var floatObjMap = make(map[*C.PyObject]*Float)
+
 // FloatType is the Type object that represents the Float type.
-var FloatType = (*Type)(unsafe.Pointer(C.getBasePyType(C.GoPyFloat_Type)))
+var FloatType = newType((*C.PyObject)(unsafe.Pointer(C.getBasePyType(C.GoPyFloat_Type))))
 
 func floatCheck(obj Object) bool {
 	return C.floatCheck(c(obj)) != 0
 }
 
 func newFloat(obj *C.PyObject) *Float {
-	return (*Float)(unsafe.Pointer(obj))
+	if f, ok := floatObjMap[obj]; ok {
+		return f
+	}
+	f := &Float{o: (*C.PyFloatObject)(unsafe.Pointer(obj))}
+	floatObjMap[obj] = f
+	return f
 }
 
 func NewFloat(v float64) (*Float, error) {

--- a/function.go
+++ b/function.go
@@ -14,14 +14,21 @@ import "unsafe"
 // using the "def" statement.
 type Function struct {
 	AbstractObject
-	o C.PyFunctionObject
+	o *C.PyFunctionObject
 }
 
+var functionObjMap = make(map[*C.PyObject]*Function)
+
 // FunctionType is the Type object that represents the Function type.
-var FunctionType = (*Type)(unsafe.Pointer(C.getBasePyType(C.GoPyFunction_Type)))
+var FunctionType = newType((*C.PyObject)(unsafe.Pointer(C.getBasePyType(C.GoPyFunction_Type))))
 
 func newFunction(obj *C.PyObject) *Function {
-	return (*Function)(unsafe.Pointer(obj))
+	if f, ok := functionObjMap[obj]; ok {
+		return f
+	}
+	f := &Function{o: (*C.PyFunctionObject)(unsafe.Pointer(obj))}
+	functionObjMap[obj] = f
+	return f
 }
 
 func functionCheck(obj Object) bool {

--- a/list.go
+++ b/list.go
@@ -19,18 +19,25 @@ import (
 // the PyList_XXX functions from the Python C API.
 type List struct {
 	AbstractObject
-	o C.PyListObject
+	o *C.PyListObject
 }
 
+var listObjMap = make(map[*C.PyObject]*List)
+
 // ListType is the Type object that represents the List type.
-var ListType = (*Type)(unsafe.Pointer(C.getBasePyType(C.GoPyList_Type)))
+var ListType = newType((*C.PyObject)(unsafe.Pointer(C.getBasePyType(C.GoPyList_Type))))
 
 func listCheck(obj Object) bool {
 	return C.listCheck(c(obj)) != 0
 }
 
 func newList(obj *C.PyObject) *List {
-	return (*List)(unsafe.Pointer(obj))
+	if l, ok := listObjMap[obj]; ok {
+		return l
+	}
+	l := &List{o: (*C.PyListObject)(unsafe.Pointer(obj))}
+	listObjMap[obj] = l
+	return l
 }
 
 // NewList creates a new Python List instance.  The created list has initial

--- a/long.go
+++ b/long.go
@@ -16,11 +16,13 @@ import (
 type Long struct {
 	AbstractObject
 	NumberProtocol
-	o C.PyLongObject
+	o *C.PyLongObject
 }
 
+var longObjMap = make(map[*C.PyObject]*Long)
+
 // LongType is the Type object that represents the Long type.
-var LongType = (*Type)(unsafe.Pointer(C.getBasePyType(C.GoPyLong_Type)))
+var LongType = newType((*C.PyObject)(unsafe.Pointer(C.getBasePyType(C.GoPyLong_Type))))
 
 func longCheck(obj Object) bool {
 	if obj == nil {
@@ -30,7 +32,12 @@ func longCheck(obj Object) bool {
 }
 
 func newLong(obj *C.PyObject) *Long {
-	return (*Long)(unsafe.Pointer(obj))
+	if l, ok := longObjMap[obj]; ok {
+		return l
+	}
+	l := &Long{o: (*C.PyLongObject)(unsafe.Pointer(obj))}
+	longObjMap[obj] = l
+	return l
 }
 
 func NewLong(i int64) *Long {

--- a/module.go
+++ b/module.go
@@ -10,10 +10,7 @@ package py
 // static inline void decref(PyObject *obj) { Py_DECREF(obj); }
 import "C"
 
-import (
-	"fmt"
-	"unsafe"
-)
+import "unsafe"
 
 type Module struct {
 	AbstractObject
@@ -141,8 +138,6 @@ func (mod *Module) AddObject(name string, obj Object) error {
 
 	cname := C.CString(name)
 	defer C.free(unsafe.Pointer(cname))
-
-	fmt.Printf("AddObject: [%s] = %T\n", name, obj)
 
 	ret := C.PyModule_AddObject(c(mod), cname, c(obj))
 	if ret < 0 {

--- a/number.go
+++ b/number.go
@@ -54,7 +54,7 @@ type Number interface {
 type number struct {
 	AbstractObject
 	NumberProtocol
-	o C.PyObject
+	o *C.PyObject
 }
 
 func cnp(n *NumberProtocol) *C.PyObject {

--- a/object.go
+++ b/object.go
@@ -13,6 +13,7 @@ package py
 import "C"
 
 import (
+	"fmt"
 	"reflect"
 	"sync"
 	"unsafe"
@@ -42,12 +43,14 @@ type Object interface {
 }
 
 // None is the Python equivalent to nil.
-var None = (*NoneObject)(unsafe.Pointer(&C._Py_NoneStruct))
+var nonePtr = (*C.PyObject)(unsafe.Pointer(&C._Py_NoneStruct))
+var None = &NoneObject{o: nonePtr}
 
 // NoneObject is the type of the None value.  The only value of this type is
 // None.
 type NoneObject struct {
 	AbstractObject
+	o *C.PyObject
 }
 
 func (n *NoneObject) String() string {
@@ -58,7 +61,11 @@ func c(obj Object) *C.PyObject {
 	if obj == nil {
 		return nil
 	}
-	return (*C.PyObject)(unsafe.Pointer(obj.Base()))
+	b := obj.Base()
+	if b.o == nil {
+		panic(fmt.Sprintf("nil! %T", obj))
+	}
+	return obj.Base().o
 }
 
 func stringify(obj Object) string {
@@ -91,8 +98,10 @@ func getType(pyType *C.PyTypeObject) (*Class, bool) {
 }
 
 func obj2Class(c *Class, obj *C.PyObject) (Object, bool) {
-	vp := reflect.NewAt(reflect.TypeOf(c.Pointer), unsafe.Pointer(&obj))
-	o, ok := vp.Elem().Interface().(Object)
+	// vp := reflect.NewAt(reflect.TypeOf(c.Pointer), unsafe.Pointer(&obj))
+	vp := reflect.New(reflect.TypeOf(c.Pointer).Elem())
+	o, ok := vp.Interface().(Object)
+	o.Base().o = obj
 	return o, ok
 }
 
@@ -101,8 +110,7 @@ func newObject(obj *C.PyObject) Object {
 		return nil
 	}
 
-	o := unsafe.Pointer(obj)
-	if o == unsafe.Pointer(None) {
+	if obj == nonePtr {
 		return None
 	}
 
@@ -127,35 +135,35 @@ func newObject(obj *C.PyObject) Object {
 
 	switch C.getBaseGoPyType(obj) {
 	case C.GoPyList_Type:
-		return (*List)(o)
+		return newList(obj)
 	case C.GoPyTuple_Type:
-		return (*Tuple)(o)
+		return newTuple(obj)
 	case C.GoPyDict_Type:
-		return (*Dict)(o)
+		return newDict(obj)
 	case C.GoPyUnicode_Type:
-		return (*Unicode)(o)
+		return newUnicode(obj)
 	case C.GoPyBool_Type:
 		return newBool(obj)
 	case C.GoPyLong_Type:
-		return (*Long)(o)
+		return newLong(obj)
 	case C.GoPyFloat_Type:
-		return (*Float)(o)
+		return newFloat(obj)
 	case C.GoPyModule_Type:
-		return (*Module)(o)
+		return newModule(obj)
 	case C.GoPyType_Type:
-		return (*Type)(o)
+		return newType(obj)
 	case C.GoPyCode_Type:
-		return (*Code)(o)
+		return newCode(obj)
 	case C.GoPyCFunction_Type:
-		return (*CFunction)(o)
+		return newCFunction(obj)
 	case C.GoPyComplex_Type:
-		return (*Complex)(o)
+		return newComplex(obj)
 	case C.GoPyFrozenSet_Type:
-		return (*FrozenSet)(o)
+		return newFrozenSet(obj)
 	case C.GoPySet_Type:
-		return (*Set)(o)
+		return newSet(obj)
 	case C.GoPyFunction_Type:
-		return (*Function)(o)
+		return newFunction(obj)
 	}
 	if C.exceptionCheck(obj) != 0 {
 		return newException(obj)

--- a/tuple.go
+++ b/tuple.go
@@ -17,11 +17,13 @@ import (
 
 type Tuple struct {
 	AbstractObject
-	o C.PyTupleObject
+	o *C.PyTupleObject
 }
 
+var tupleObjMap = make(map[*C.PyObject]*Tuple)
+
 // TupleType is the Type object that represents the Tuple type.
-var TupleType = (*Type)(unsafe.Pointer(C.getBasePyType(C.GoPyTuple_Type)))
+var TupleType = newType((*C.PyObject)(unsafe.Pointer(C.getBasePyType(C.GoPyTuple_Type))))
 
 func tupleCheck(obj Object) bool {
 	if obj == nil {
@@ -31,7 +33,12 @@ func tupleCheck(obj Object) bool {
 }
 
 func newTuple(obj *C.PyObject) *Tuple {
-	return (*Tuple)(unsafe.Pointer(obj))
+	if t, ok := tupleObjMap[obj]; ok {
+		return t
+	}
+	t := &Tuple{o: (*C.PyTupleObject)(unsafe.Pointer(obj))}
+	tupleObjMap[obj] = t
+	return t
 }
 
 // NewTuple returns a new *Tuple of the specified size.  However the entries are

--- a/unicode.go
+++ b/unicode.go
@@ -12,18 +12,25 @@ import "unsafe"
 
 type Unicode struct {
 	AbstractObject
-	o C.PyUnicodeObject
+	o *C.PyUnicodeObject
 }
 
+var unicodeObjMap = make(map[*C.PyObject]*Unicode)
+
 // UnicodeType is the Type object that represents the Unicode type.
-var UnicodeType = (*Type)(unsafe.Pointer(C.getBasePyType(C.GoPyUnicode_Type)))
+var UnicodeType = newType((*C.PyObject)(unsafe.Pointer(C.getBasePyType(C.GoPyUnicode_Type))))
 
 func unicodeCheck(obj Object) bool {
 	return C.unicodeCheck(c(obj)) != 0
 }
 
 func newUnicode(obj *C.PyObject) *Unicode {
-	return (*Unicode)(unsafe.Pointer(obj))
+	if u, ok := unicodeObjMap[obj]; ok {
+		return u
+	}
+	u := &Unicode{o: (*C.PyUnicodeObject)(unsafe.Pointer(obj))}
+	unicodeObjMap[obj] = u
+	return u
 }
 
 func NewUnicode(s string) (*Unicode, error) {


### PR DESCRIPTION
This fixes all the dirty allocation tricks Gopy was trying to do. I don't yet know if this is completely memory safe. Also, I thought I needed to switch everything to maps, but having a *GoType that actually points to C memory shouldn't be a problem, so much of this might be able to be reverted and still work correctly.
